### PR TITLE
Removes redundant check on insert

### DIFF
--- a/lists/dll/dll.go
+++ b/lists/dll/dll.go
@@ -66,10 +66,6 @@ func (l *DLL) InsertAt(idx int, val interface{}) error {
 	if idx > l.length {
 		return ErrOutOfBounds
 	}
-	if l.length == 0 {
-		l.Prepend(val)
-		return nil
-	}
 	switch idx {
 	case 0:
 		l.Prepend(val)

--- a/lists/dll/nodeOps.go
+++ b/lists/dll/nodeOps.go
@@ -40,10 +40,6 @@ func (l *DLL) InsertNodeAt(idx int, n *Node) error {
 	if idx > l.length {
 		return ErrOutOfBounds
 	}
-	if l.length == 0 {
-		l.PrependNode(n)
-		return nil
-	}
 	switch idx {
 	case 0:
 		l.PrependNode(n)


### PR DESCRIPTION
dll.InsertAt()
dll.InsertNodeAt()